### PR TITLE
Upgrade version-incrementor due to dependency pinning problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ prep_version_incrementor:
 	@echo "Installing version-incrementor with pipenv"
 	@pip install pipenv --upgrade
 	@pipenv --python $(PYTHON_VERSION)
-	@pipenv run pip install -i https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple version-incrementor==0.2.0
+	@pipenv run pip install -i https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple version-incrementor==0.7
 
 clean: ## Remove the docker image
 	@echo '********** Cleaning up ************'


### PR DESCRIPTION
The previous version had issues due to the removal of a module in later versions of GitPython. Version 0.7.0 pins versions correctly.