### PR TITLE
Add snapshot endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ Posting to `/component/hmrc/1.4.0/hmrcPageHeading` with a body of `{"text": "Pag
 
 `GET` from `/example-usage/$$ORG$$/$$COMPONENT_NAME$$` where `$$ORG$$` is the owner of the design system (one of `hmrc` or `govuk`) and `$$COMPONENT_NAME$$` is the name of the component required e.g. `govukSelect`, `govukButton`, `hmrcAccountHeader`
 
-The response will contain the Nunjucks and HTML output of each available example for that component.
+The response will contain the Nunjucks and HTML output of each available example from the design system for that component.
 
 The response structure is as follows:
 
-`
+```
   [
     {
       html: '<div>some markup</div>',
@@ -62,7 +62,31 @@ The response structure is as follows:
       nunjucks: '{% some Nunjucks %}'
     }
   ]
-`
+```
+
+### 4.
+
+`GET` from `/snapshot/$$ORG$$/$$VERSION$$` where `$$ORG$$` is the owner of the design system (one of `hmrc` or `govuk`) and `$$VERSION$$` is the NPM package version (e.g. `1.0.0`, `1.4.0`)
+
+The response will contain the component name, a unique ID, the input params and HTML output of each available example for that component in the github project.
+
+The response structure is as follows:
+
+```
+  [
+    {
+      "componentName": "govukButton",
+      "exampleName": "start link",
+      "exampleId": "button-start-link",
+      "input": {
+        "text": "Start now link button",
+        "href": "/",
+        "isStartButton": true
+      },
+      "output": "<a href=\"/\" role=\"button\" draggable=\"false\" class=\"govuk-button govuk-button--start\" data-module=\"govuk-button\">\n  Start now link button\n  <svg class=\"govuk-button__start-icon\" xmlns=\"http://www.w3.org/2000/svg\" width=\"17.5\" height=\"19\" viewBox=\"0 0 33 40\" aria-hidden=\"true\" focusable=\"false\">\n    <path fill=\"currentColor\" d=\"M0 0h13l20 20-20 20H0l20-20z\"/>\n  </svg>\n</a>"
+    }
+  ]
+```
 
 This is currently hosted at https://template-service-spike.herokuapp.com
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -838,6 +838,11 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "optional": true
     },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   "license": "ISC",
   "dependencies": {
     "axios": "^0.19.0",
+    "bluebird": "^3.7.2",
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "gray-matter": "^4.0.2",
+    "js-yaml": "^3.13.1",
     "marked": "^0.7.0",
     "nunjucks": "^3.2.0",
     "tar": "^6.0.2"

--- a/src/app/controllers/componentController.js
+++ b/src/app/controllers/componentController.js
@@ -8,7 +8,10 @@ const {
   getComponentIdentifier,
   getNpmDependency,
   getSubDependencies,
-  getOrgDetails
+  getDirectories,
+  getOrgDetails,
+  respondWithError,
+  joinWithCurrentUrl
 } = require('../../util')
 
 const router = express.Router()
@@ -43,6 +46,7 @@ router.post('/:org/:version/:component', jsonParser, async (req, res) => {
           res.status(500).send(`An error occurred: ${err.message}`)
         }
       })
+      .catch(respondWithError(res))
   }
 })
 

--- a/src/app/controllers/componentController.js
+++ b/src/app/controllers/componentController.js
@@ -1,51 +1,28 @@
 const express = require('express')
-const nunjucks = require('../../lib/nunjucks')
 
 const bodyParser = require('body-parser')
 const jsonParser = bodyParser.json()
 
 const {
-  getComponentIdentifier,
-  getNpmDependency,
-  getSubDependencies,
-  getDirectories,
+  renderComponent,
   getOrgDetails,
   respondWithError,
-  joinWithCurrentUrl
+  versionIsCompatible,
+  getConfiguredNunjucksForOrganisation
 } = require('../../util')
 
 const router = express.Router()
 
 router.post('/:org/:version/:component', jsonParser, async (req, res) => {
-  const {
-    body = {},
-    params: {
-      version,
-      component,
-      org
-    }
-  } = req
-  const {label, minimumSupported, dependencies} = getOrgDetails(org)
+  const {version, org, component} = req.params
+  const orgDetails = getOrgDetails(org)
 
-
-  if (parseFloat(version) < minimumSupported) {
-    res.status(500).send(`This version of ${label} is not supported`)
+  if (!versionIsCompatible(version, orgDetails)) {
+    res.status(500).send(`This version of ${(orgDetails.label)} is not supported`)
   } else {
-    getNpmDependency(label, version)
-      .then(path => getSubDependencies(path, dependencies || []).then(dependencyPaths => [path, `${path}/views/layouts`, ...dependencyPaths]))
-      .then(nunjucksPaths => {
-        const params = JSON.stringify(body, null, 2)
-        const nunjucksString = `{% from '${org}/components/${getComponentIdentifier(org, component)}/macro.njk' import ${component} %}{{${component}(${params})}}`
-
-        try {
-          res.send(nunjucks(nunjucksPaths).renderString(nunjucksString))
-        } catch (err) {
-          console.error(err.message)
-          console.error(err.stack)
-          console.info('template was:', nunjucksString)
-          res.status(500).send(`An error occurred: ${err.message}`)
-        }
-      })
+    getConfiguredNunjucksForOrganisation(getOrgDetails(orgDetails.code), version)
+      .then(nunjucks => renderComponent(orgDetails.code, component, req.body, nunjucks, ))
+      .then(rendered => res.send(rendered))
       .catch(respondWithError(res))
   }
 })

--- a/src/app/controllers/examplesController.js
+++ b/src/app/controllers/examplesController.js
@@ -60,14 +60,12 @@ router.get('/:org/:component', async (req, res) => {
     )
     .then(paths => {
       const componentPath = `${paths.dependencyPath}/${componentRootPath}/${substitutionMap[componentIdentifier] || componentIdentifier}`
-      const examples = getDirectories(componentPath)
 
 
-      return Promise.all(
-        examples.map(example => getDataFromFile(`${componentPath}/${example}/index.njk`, paths.subdependecyPaths, {
+      return getDirectories(componentPath)
+        .map(example => getDataFromFile(`${componentPath}/${example}/index.njk`, paths.subdependecyPaths, {
           name: `${componentIdentifier}/${example}`
         }))
-      )
     })
     .then(result => {
       res.send(result)

--- a/src/app/controllers/snapshotController.js
+++ b/src/app/controllers/snapshotController.js
@@ -1,0 +1,79 @@
+const express = require('express')
+const Promise = require('bluebird')
+const YAML = require('js-yaml')
+
+const bodyParser = require('body-parser')
+const jsonParser = bodyParser.json()
+const fs = Promise.promisifyAll(require('fs'))
+
+const {
+  getConfiguredNunjucksForOrganisation,
+  getDirectories,
+  getOrgDetails,
+  respondWithError,
+  getDependency,
+  versionIsCompatible,
+  getComponentSignature,
+  renderComponent
+} = require('../../util')
+
+const flatten = arr => arr.reduce((previous, current) => previous.concat(...current), [])
+
+const uniqueNameChecker = () => {
+  const usedNames = []
+  return name => {
+    let duplicateCount = 1
+    let newName
+    if (usedNames.includes(name)) {
+      do {
+        duplicateCount++
+        newName = name + duplicateCount
+      } while (usedNames.includes(newName))
+      usedNames.push(newName)
+      return newName
+    } else {
+      usedNames.push(name)
+      return name
+    }
+  }
+}
+
+const router = express.Router()
+
+router.get('/:org/:version', jsonParser, async (req, res) => {
+  const {version, org} = req.params
+  const orgDetails = getOrgDetails(org, version)
+  const ensureUniqueName = uniqueNameChecker()
+
+  if (!versionIsCompatible(version, orgDetails)) {
+    res.status(500).send(`This version of ${(orgDetails.label)} is not supported`)
+  } else {
+    Promise.all([
+      getConfiguredNunjucksForOrganisation(orgDetails, version),
+      getDependency(`${orgDetails.label}-github`, orgDetails.githubUrl, version)
+        .then(path => getDirectories(`${path}/${orgDetails.componentDir}`)
+          .map(componentName => fs.readFileAsync(`${path}/${orgDetails.componentDir}/${componentName}/${componentName}.yaml`, 'utf8')
+            .then(contents => YAML.safeLoad(contents, {json: true}))
+            .then(componentInfo => componentInfo.type === 'layout' ? [] : componentInfo.examples)
+            .catch(err => {
+              return []
+            })
+            .map(example => ({
+              componentName: getComponentSignature(orgDetails.code, componentName),
+              exampleName: example.name,
+              exampleId: ensureUniqueName(`${componentName}-${example.name}`.replace(/\s/g, '-')),
+              input: example.data
+            }))
+          )
+          .then(flatten))
+    ])
+      .spread((configuredNunjucks, examples) => examples.map(example => ({
+        ... example,
+        output: renderComponent(org, example.componentName, example.input, configuredNunjucks)
+      })))
+      .then(out => res.send(out))
+      .catch(respondWithError(res))
+  }
+})
+
+module.exports = router

--- a/src/app/index.test.js
+++ b/src/app/index.test.js
@@ -478,6 +478,67 @@ describe("X-GOVUK Component Renderer", () => {
     })
   })
 
+  describe('snapshotter', () => {
+    it('should return a snapshot from a recent GOVUK version', () => {
+      return request(app)
+        .get("/snapshot/govuk/3.6.0")
+        .expect(200)
+        .then(response => {
+          expect(response.body.length).toBe(188)
+          expect(response.body.map(x => x.exampleId).filter(x => x.startsWith('footer-'))).toEqual([
+            'footer-default',
+            'footer-with-meta',
+            'footer-with-custom-meta',
+            'footer-with-meta-links-and-meta-content',
+            'footer-with-custom-meta2',
+            'footer-with-navigation',
+            'footer-GOV.UK',
+            'footer-Three-equal-columns'
+          ])
+        })
+    })
+    it('should return a snapshot from a recent HMRC version', () => {
+      return request(app)
+        .get("/snapshot/hmrc/1.12.0")
+        .expect(200)
+        .then(response => {
+          expect(response.body.length).toBe(42)
+          expect(response.body.map(x => x.exampleId).filter(x => x.startsWith('currency-'))).toEqual([
+            'currency-input-default'
+          ])
+        })
+    })
+    it('should return a snapshot from an older HMRC version', () => {
+      return request(app)
+        .get("/snapshot/hmrc/1.1.0")
+        .expect(200)
+        .then(response => {
+          expect(response.body.length).toBe(38)
+          expect(response.body.map(x => x.exampleId).filter(x => x.startsWith('currency-'))).toEqual([])
+        })
+    })
+    it('should render using the correct govuk-frontend version', () => {
+      return Promise.all([
+        request(app)
+          .get("/snapshot/govuk/3.6.0")
+          .expect(200)
+          .then(response => {
+            const output = response.body.filter(x => x.exampleId === 'button-start-link')[0].output
+            expect(output.includes('role="presentation"')).toBe(false)
+            expect(output.includes('aria-hidden="true"')).toBe(true)
+          }),
+        request(app)
+          .get("/snapshot/govuk/3.5.0")
+          .expect(200)
+          .then(response => {
+            const output = response.body.filter(x => x.exampleId === 'button-start-link')[0].output
+            expect(output.includes('role="presentation"')).toBe(true)
+            expect(output.includes('aria-hidden="true"')).toBe(false)
+          })
+        ])
+    })
+  })
+
   describe('Root page', () => {
     it('should return rendered markdown of README.md', (done) => {
       let expected

--- a/src/app/index.test.js
+++ b/src/app/index.test.js
@@ -374,6 +374,30 @@ describe("X-GOVUK Component Renderer", () => {
           done()
         })
     })
+
+    it('should list GOVUK components which have examples', () => {
+      return request(app)
+        .get("/example-usage/govuk")
+        .expect(200)
+        .then(response => {
+          expect(response.body.length > 0).toBe(true)
+          response.body.forEach(item => {
+            expect(item.startsWith('/example-usage/govuk/')).toBe(true)
+          })
+        })
+    })
+
+    it('should list HMRC components which have examples', () => {
+      return request(app)
+        .get("/example-usage/hmrc")
+        .expect(200)
+        .then(response => {
+          expect(response.body.length > 0).toBe(true)
+          response.body.forEach(item => {
+            expect(item.startsWith('/example-usage/hmrc/')).toBe(true)
+          })
+        })
+    })
   })
 
   describe('GOVUK template', () => {

--- a/src/app/routes.js
+++ b/src/app/routes.js
@@ -3,6 +3,7 @@ const express = require('express')
 const rootController = require('./controllers/rootController')
 const examplesController = require('./controllers/examplesController')
 const componentController = require('./controllers/componentController')
+const snapshotController = require('./controllers/snapshotController')
 const templateController = require('./controllers/templateController')
 
 const router = express.Router()
@@ -10,6 +11,7 @@ const router = express.Router()
 router.use('/example-usage', examplesController)
 router.use('/component', componentController)
 router.use('/template', templateController)
+router.use('/snapshot', snapshotController)
 router.use(rootController)
 
 module.exports = router

--- a/src/util.js
+++ b/src/util.js
@@ -134,6 +134,19 @@ const getSubDependencies = (dependencyPath, dependencies) => Promise.all(depende
   return getNpmDependency(dependency, trimmedVersion)
 }))
 
+const respondWithError = (res) => (err) => {
+  if (err) {
+    console.error(err.message)
+    console.error(err.stack)
+    res.status(500).send(err)
+  } else {
+    console.error('failed but no error provided')
+    res.status(500).send('An error occurred')
+  }
+}
+
+const joinWithCurrentUrl = req => path => `${req.originalUrl.replace(/\/+$/, '')}/${path}`
+
 module.exports = {
   getComponentIdentifier,
   getDataFromFile,
@@ -142,5 +155,7 @@ module.exports = {
   getNpmDependency,
   getLatestSha,
   getOrgDetails,
-  getSubDependencies
+  getSubDependencies,
+  respondWithError,
+  joinWithCurrentUrl
 }


### PR DESCRIPTION
Adding an endpoint to get a "snapshot" - a set of example inputs and outputs which used to be provided by `x-frontend-snapshotter`.

The examples here come from the `govuk-frontend` or `hmrc-frontend` projects, there's a plan to host additional examples elsewhere which will be included in the snapshot.