### PR TITLE
Prevent insecure http requests during docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dependencies
 Pipfile
 /target/
 /project/
+.version

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,13 @@
 ARG NODE_VERSION
 ARG DOCKERHUB=dockerhub.tax.service.gov.uk
-FROM ${DOCKERHUB}/node:${NODE_VERSION:-10.15.1}-slim
+
+# NodeJS docker images are tagged with:
+# - the NodeJS version they provide
+# - "-bullseye", the name of the debian distro they are built from
+# - "-slim", to indicate they only include the minimal system packages
+#   needed to run nodejs so the image is smaller with less security surface
+# For more context https://hub.docker.com/_/node
+FROM ${DOCKERHUB}/node:${NODE_VERSION}-bullseye-slim
 
 WORKDIR /x-govuk-component-renderer
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
 set -eux
 
-apt-get update
 npm install


### PR DESCRIPTION
by patching our dockerfile so that it uses https when making apt requests, also:
- ~~Unpinned the minor python version, because 3.7.4 didn't seem to build for me locally - doesn't seem to be any value in pinning it that precisely~~
- Ignore .version file, it's generated during `make build` - so it doesn't get committed by mistake
- Bump the docker base image to use the latest LTS release of debian called "bullseye" - because current one (called "buster") was released in 2019 and is now [out of debian security support](https://endoflife.date/debian)
