### PR TITLE
PLATUI-2293: remove pypi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ push_image: ## Push the docker image to artifactory
 prep_version_incrementor:
 	@echo "Renaming requirements to prevent pipenv trying to convert it"
 	@echo "Installing version-incrementor with pipenv"
-	@pip install pipenv --upgrade
+	@pip install -i https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple pipenv --upgrade
 	@pipenv --python $(PYTHON_VERSION)
 	@pipenv run pip install -i https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple 'version-incrementor<2'
 


### PR DESCRIPTION
Because it's blocked from be requested by B&D and we need to request stuff via artefactory instead. We were already doing this for some requests but it was missing from one where we were installing pipenv