### PR TITLE
NOJIRA add npm audit exclusion; fix failing test due to switch to camelCase naming

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,4 +1,5 @@
 {
+  "GHSA-67hx-6x53-jw92": "@babel/traverse - devDependency, no risk given our usage",
   "GHSA-c2qf-rxjj-qqgw": "semver - devDependency, no risk given our usage",
   "GHSA-f8q6-p94x-37v3": "minimatch - devDependency, no risk given our usage",
   "GHSA-hrpp-h998-j3pp": "qs - devDependency, no risk given our usage",

--- a/test/app/index.test.js
+++ b/test/app/index.test.js
@@ -292,14 +292,14 @@ describe('X-GOVUK Component Renderer', () => {
   <label class="govuk-label" for="file-upload-1">
     Upload a file
   </label>
-  <input class="govuk-file-upload" id="file-upload-1" name="file-upload-1" type="file">
+  <input class="govuk-file-upload" id="file-upload-1" name="fileUpload1" type="file">
 </div>`,
         name: 'file-upload/default',
         nunjucks: `{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 
 {{ govukFileUpload({
   id: "file-upload-1",
-  name: "file-upload-1",
+  name: "fileUpload1",
   label: {
     text: "Upload a file"
   }
@@ -313,14 +313,14 @@ describe('X-GOVUK Component Renderer', () => {
   <p id="file-upload-1-error" class="govuk-error-message">
   <span class="govuk-visually-hidden">Error:</span> The CSV must be smaller than 2MB
   </p>
-  <input class="govuk-file-upload govuk-file-upload--error" id="file-upload-1" name="file-upload-1" type="file" aria-describedby="file-upload-1-error">
+  <input class="govuk-file-upload govuk-file-upload--error" id="file-upload-1" name="fileUpload1" type="file" aria-describedby="file-upload-1-error">
 </div>`,
         name: 'file-upload/error',
         nunjucks: `{% from "govuk/components/file-upload/macro.njk" import govukFileUpload %}
 
 {{ govukFileUpload({
   id: "file-upload-1",
-  name: "file-upload-1",
+  name: "fileUpload1",
   label: {
     text: "Upload a file"
   },


### PR DESCRIPTION
Tests were failing apparently due to [this change in the GOVUK design system](https://github.com/alphagov/govuk-design-system/commit/83c26d561d327f917619df9343b412d5369d9771), to use camelCase naming convention instead of kebab-case in examples.