### PR TITLE
PLATUI 2757 fix govuk v5

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,4 +1,5 @@
 {
+  "GHSA-jchw-25xp-jwwc": "follow-redirects - devDependency, no risk given our usage",
   "GHSA-wf5p-g6vw-rhxx": "axios - devDependency, no risk given our usage",
   "GHSA-67hx-6x53-jw92": "@babel/traverse - devDependency, no risk given our usage",
   "GHSA-c2qf-rxjj-qqgw": "semver - devDependency, no risk given our usage",

--- a/README.md
+++ b/README.md
@@ -88,7 +88,5 @@ The response structure is as follows:
   ]
 ```
 
-This is currently hosted at https://template-service-spike.herokuapp.com
-
 Limitations for the current phase:
  - We don't currently support `caller` blocks being fed in

--- a/src/app/controllers/examplesController.js
+++ b/src/app/controllers/examplesController.js
@@ -64,17 +64,17 @@ router.get('/:org/:component', (req, res) => {
 
   getLatestExamples(name, branch)
     .then((dependencyPath) => getSubDependencies(dependencyPath, dependencies)
-      .then((subdependecyPaths) => ({
+      .then((subDependencyPaths) => ({
         dependencyPath,
-        subdependecyPaths: [
-          ...subdependecyPaths,
+        subDependencyPaths: [
+          ...subDependencyPaths,
           ...nunjucksPaths.map((x) => path.join(dependencyPath, x))],
       })))
     .then((paths) => {
       const componentPath = `${paths.dependencyPath}/${componentRootPath}/${substitutionMap[componentIdentifier] || componentIdentifier}`;
 
       return getDirectories(componentPath)
-        .map((example) => getDataFromFile(`${componentPath}/${example}/index.njk`, paths.subdependecyPaths).catch((err) => {
+        .map((example) => getDataFromFile(`${componentPath}/${example}/index.njk`, paths.subDependencyPaths).catch((err) => {
           const preparedMessage = `This example couldn't be prepared - ${err.message}`;
           return {
             html: preparedMessage,


### PR DESCRIPTION
PLATUI-2757 Take version-specific distribution dirs into account when rendering examples; add npm audit exclusion

Need to use version-specific distribution dirs for compatibility with both GOVUK and HMRC design systems, which may be using different underlying govuk-frontend versions at any given time